### PR TITLE
Session refactoring

### DIFF
--- a/NotificareKit/Sources/Internals/Modules/NotificareDeviceModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareDeviceModuleImpl.swift
@@ -35,7 +35,7 @@ internal class NotificareDeviceModuleImpl: NSObject, NotificareModule, Notificar
             if device.appVersion != NotificareUtils.applicationVersion {
                 // It's not the same version, let's log it as an upgrade.
                 NotificareLogger.debug("New version detected")
-                Notificare.shared.events().logApplicationUpgrade { _ in }
+                Notificare.shared.eventsImplementation().logApplicationUpgrade { _ in }
             }
 
             instance.register(transport: device.transport, token: device.id, userId: device.userId, userName: device.userName) { result in
@@ -57,8 +57,8 @@ internal class NotificareDeviceModuleImpl: NSObject, NotificareModule, Notificar
                 switch result {
                 case .success:
                     // We will log the Install & Registration events here since this will execute only one time at the start.
-                    Notificare.shared.events().logApplicationInstall { _ in }
-                    Notificare.shared.events().logApplicationRegistration { _ in }
+                    Notificare.shared.eventsImplementation().logApplicationInstall { _ in }
+                    Notificare.shared.eventsImplementation().logApplicationRegistration { _ in }
 
                     completion(.success(()))
                 case let .failure(error):

--- a/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
@@ -36,71 +36,6 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
 
     // MARK: - Notificare Events
 
-    func logApplicationInstall(_ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Install", completion)
-    }
-
-    @available(iOS 13.0, *)
-    func logApplicationInstall() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            logApplicationInstall { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
-    func logApplicationRegistration(_ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Registration", completion)
-    }
-
-    @available(iOS 13.0, *)
-    func logApplicationRegistration() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            logApplicationRegistration { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
-    func logApplicationUpgrade(_ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Upgrade", completion)
-    }
-
-    @available(iOS 13.0, *)
-    func logApplicationUpgrade() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            logApplicationUpgrade { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
-    func logApplicationOpen(_ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Open", completion)
-    }
-
-    @available(iOS 13.0, *)
-    func logApplicationOpen() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            logApplicationOpen { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
-    func logApplicationClose(sessionLength: Double, _ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Close", data: ["length": String(sessionLength)], completion)
-    }
-
-    @available(iOS 13.0, *)
-    func logApplicationClose(sessionLength: Double) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            logApplicationClose(sessionLength: sessionLength) { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
     func logNotificationOpen(_ id: String, _ completion: @escaping NotificareCallback<Void>) {
         log("re.notifica.event.notification.Open", data: nil, for: id, completion)
     }
@@ -153,6 +88,26 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
     }
 
     // MARK: - Internal API
+
+    internal func logApplicationInstall(_ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Install", completion)
+    }
+
+    internal func logApplicationRegistration(_ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Registration", completion)
+    }
+
+    internal func logApplicationUpgrade(_ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Upgrade", completion)
+    }
+
+    internal func logApplicationOpen(_ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Open", completion)
+    }
+
+    internal func logApplicationClose(sessionLength: Double, _ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Close", data: ["length": String(sessionLength)], completion)
+    }
 
     private func log(_ event: NotificareEvent, _ completion: @escaping NotificareCallback<Void>) {
         NotificareRequest.Builder()

--- a/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
@@ -101,12 +101,12 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
         log("re.notifica.event.application.Upgrade", completion)
     }
 
-    internal func logApplicationOpen(_ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Open", completion)
+    internal func logApplicationOpen(sessionId: String, _ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Open", sessionId: sessionId, completion)
     }
 
-    internal func logApplicationClose(sessionLength: Double, _ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.application.Close", data: ["length": String(sessionLength)], completion)
+    internal func logApplicationClose(sessionId: String, sessionLength: Double, _ completion: @escaping NotificareCallback<Void>) {
+        log("re.notifica.event.application.Close", data: ["length": String(sessionLength)], sessionId: sessionId, completion)
     }
 
     private func log(_ event: NotificareEvent, _ completion: @escaping NotificareCallback<Void>) {

--- a/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareEventsModuleImpl.swift
@@ -37,7 +37,7 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
     // MARK: - Notificare Events
 
     func logNotificationOpen(_ id: String, _ completion: @escaping NotificareCallback<Void>) {
-        log("re.notifica.event.notification.Open", data: nil, for: id, completion)
+        log("re.notifica.event.notification.Open", data: nil, notificationId: id, completion)
     }
 
     @available(iOS 13.0, *)
@@ -64,7 +64,7 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
 
     // MARK: - Notificare Internal Events
 
-    func log(_ event: String, data: NotificareEventData?, for notification: String?, _ completion: @escaping NotificareCallback<Void>) {
+    func log(_ event: String, data: NotificareEventData?, sessionId: String?, notificationId: String?, _ completion: @escaping NotificareCallback<Void>) {
         guard let device = Notificare.shared.device().currentDevice else {
             NotificareLogger.warning("Cannot send an event before a device is registered.")
             return
@@ -78,8 +78,8 @@ internal class NotificareEventsModuleImpl: NSObject, NotificareModule, Notificar
             type: type,
             timestamp: Int64(Date().timeIntervalSince1970 * 1000),
             deviceId: device.id,
-            sessionId: Notificare.shared.session().sessionId,
-            notificationId: notification,
+            sessionId: sessionId ?? Notificare.shared.session().sessionId,
+            notificationId: notificationId,
             userId: device.userId,
             data: data
         )

--- a/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
@@ -63,7 +63,7 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
         sessionEnd = nil
 
         NotificareLogger.debug("Session '\(sessionId)' started at \(dateFormatter.string(from: sessionStart)).")
-        Notificare.shared.eventsImplementation().logApplicationOpen { _ in }
+        Notificare.shared.eventsImplementation().logApplicationOpen(sessionId: sessionId) { _ in }
     }
 
     @objc private func applicationWillResignActive() {
@@ -112,7 +112,7 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
 
             let length = sessionEnd.timeIntervalSince(sessionStart)
             NotificareLogger.info("Application closed event registered for session '\(sessionId)' with a length of \(length) seconds.")
-            Notificare.shared.eventsImplementation().logApplicationClose(sessionLength: length) { _ in }
+            Notificare.shared.eventsImplementation().logApplicationClose(sessionId: sessionId, sessionLength: length) { _ in }
 
             // Reset the session.
             self.sessionId = nil

--- a/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
@@ -13,8 +13,9 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
     internal private(set) var sessionId: String?
     private var sessionStart: Date?
     private var sessionEnd: Date?
-    private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
-    private var workItem: DispatchWorkItem?
+
+    private var backgroundTask: DispatchWorkItem?
+    private var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -39,22 +40,74 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
                                                object: nil)
     }
 
+    static func launch(_ completion: @escaping NotificareCallback<Void>) {
+        if instance.sessionId == nil, UIApplication.shared.applicationState == .active {
+            // Launch is taking place after the application came to the foreground.
+            // Start the application session.
+            instance.startSession { _ in
+                completion(.success(()))
+            }
+
+            return
+        }
+
+        completion(.success(()))
+    }
+
+    static func unlaunch(_ completion: @escaping NotificareCallback<Void>) {
+        instance.sessionEnd = Date()
+        instance.stopSession { _ in
+            completion(.success(()))
+        }
+    }
+
     // MARK: - Internal API
 
     @objc private func applicationDidBecomeActive() {
         guard UIApplication.shared.applicationState == .active else {
+            NotificareLogger.debug("The application is not active. Skipping...")
             return
+        }
+
+        if sessionId != nil {
+            NotificareLogger.debug("Resuming previous session.")
         }
 
         // Cancel any session timeout.
-        workItem?.cancel()
-        UIApplication.shared.endBackgroundTask(backgroundTask)
+        cancelBackgroundTask()
 
-        guard sessionStart == nil else {
-            NotificareLogger.debug("Resuming previous session.")
+        // Prevent multiple session starts.
+        guard sessionId == nil else { return }
+
+        guard Notificare.shared.isReady else {
+            NotificareLogger.debug("Postponing session start until Notificare is launched.")
             return
         }
 
+        startSession { _ in }
+    }
+
+    @objc private func applicationWillResignActive() {
+        guard UIApplication.shared.applicationState == .active else {
+            NotificareLogger.debug("The application is not active. Skipping...")
+            return
+        }
+
+        sessionEnd = Date()
+
+        // Wait a few seconds before sending a close event.
+        // This prevents quick app swaps, navigation pulls, etc.
+        let backgroundTask = createBackgroundTask()
+        self.backgroundTask = backgroundTask
+        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 10, execute: backgroundTask)
+
+        backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: SESSION_CLOSE_TASK_NAME) { [weak self] in
+            NotificareLogger.debug("Background task expiration handler triggered.")
+            self?.cancelBackgroundTask()
+        }
+    }
+
+    private func startSession(_ completion: @escaping NotificareCallback<Void>) {
         let sessionId = UUID().uuidString.lowercased()
         let sessionStart = Date()
 
@@ -63,65 +116,58 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
         sessionEnd = nil
 
         NotificareLogger.debug("Session '\(sessionId)' started at \(dateFormatter.string(from: sessionStart)).")
-        Notificare.shared.eventsImplementation().logApplicationOpen(sessionId: sessionId) { _ in }
+
+        Notificare.shared.eventsImplementation().logApplicationOpen(sessionId: sessionId) { result in
+            if case let .failure(error) = result {
+                NotificareLogger.warning("Failed to process an application session start.", error: error)
+            }
+
+            completion(.success(()))
+        }
     }
 
-    @objc private func applicationWillResignActive() {
-        guard UIApplication.shared.applicationState == .active else {
-            NotificareLogger.debug("Application is not active. Skipping...")
+    private func stopSession(_ completion: @escaping NotificareCallback<Void>) {
+        guard let sessionId = sessionId,
+              let sessionStart = sessionStart,
+              let sessionEnd = sessionEnd
+        else {
+            // Skip when no session has started. Should never happen.
+            completion(.success(()))
             return
         }
 
-        guard let sessionId = sessionId else {
-            NotificareLogger.debug("No session found. Skipping...")
-            return
-        }
-
-        let sessionEnd = Date()
-        self.sessionEnd = sessionEnd
+        // Reset the session.
+        self.sessionId = nil
+        self.sessionStart = nil
+        self.sessionEnd = nil
 
         NotificareLogger.debug("Session '\(sessionId)' stopped at \(dateFormatter.string(from: sessionEnd)).")
 
-        // Wait a few seconds before sending a close event.
-        // This prevents quick app swaps, navigation pulls, etc.
-        backgroundTask = UIApplication.shared.beginBackgroundTask(withName: SESSION_CLOSE_TASK_NAME) { [weak self] in
-            NotificareLogger.debug("Background task expiration handler triggered.")
-            guard let self = self else {
-                return
+        let length = sessionEnd.timeIntervalSince(sessionStart)
+        Notificare.shared.eventsImplementation().logApplicationClose(sessionId: sessionId, sessionLength: length) { result in
+            if case let .failure(error) = result {
+                NotificareLogger.warning("Failed to process an application session stop.", error: error)
             }
 
-            UIApplication.shared.endBackgroundTask(self.backgroundTask)
-            self.backgroundTask = .invalid
-            self.workItem = nil
+            completion(.success(()))
         }
-
-        let workItem = createWorkItem()
-        self.workItem = workItem
-        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 10, execute: workItem)
     }
 
-    private func createWorkItem() -> DispatchWorkItem {
+    private func createBackgroundTask() -> DispatchWorkItem {
         DispatchWorkItem {
-            guard let sessionId = self.sessionId,
-                  let sessionStart = self.sessionStart,
-                  let sessionEnd = self.sessionEnd
-            else {
-                // Skip when no session has started. Should never happen.
-                return
+            self.stopSession { _ in
+                self.cancelBackgroundTask()
             }
+        }
+    }
 
-            let length = sessionEnd.timeIntervalSince(sessionStart)
-            NotificareLogger.info("Application closed event registered for session '\(sessionId)' with a length of \(length) seconds.")
-            Notificare.shared.eventsImplementation().logApplicationClose(sessionId: sessionId, sessionLength: length) { _ in }
+    private func cancelBackgroundTask() {
+        backgroundTask?.cancel()
+        backgroundTask = nil
 
-            // Reset the session.
-            self.sessionId = nil
-            self.sessionStart = nil
-            self.sessionEnd = nil
-
-            // Clear the background task.
-            UIApplication.shared.endBackgroundTask(self.backgroundTask)
-            self.workItem = nil
+        if backgroundTaskIdentifier != .invalid {
+            UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
+            backgroundTaskIdentifier = .invalid
         }
     }
 }

--- a/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
+++ b/NotificareKit/Sources/Internals/Modules/NotificareSessionModuleImpl.swift
@@ -63,7 +63,7 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
         sessionEnd = nil
 
         NotificareLogger.debug("Session '\(sessionId)' started at \(dateFormatter.string(from: sessionStart)).")
-        Notificare.shared.events().logApplicationOpen { _ in }
+        Notificare.shared.eventsImplementation().logApplicationOpen { _ in }
     }
 
     @objc private func applicationWillResignActive() {
@@ -112,7 +112,7 @@ internal class NotificareSessionModuleImpl: NSObject, NotificareModule {
 
             let length = sessionEnd.timeIntervalSince(sessionStart)
             NotificareLogger.info("Application closed event registered for session '\(sessionId)' with a length of \(length) seconds.")
-            Notificare.shared.events().logApplicationClose(sessionLength: length) { _ in }
+            Notificare.shared.eventsImplementation().logApplicationClose(sessionLength: length) { _ in }
 
             // Reset the session.
             self.sessionId = nil

--- a/NotificareKit/Sources/Internals/NotificareInternals.swift
+++ b/NotificareKit/Sources/Internals/NotificareInternals.swift
@@ -7,9 +7,9 @@ import Foundation
 public enum NotificareInternals {
     public enum Module: String, CaseIterable {
         // Embedded modules
-        case device = "NotificareKit.NotificareDeviceModuleImpl"
         case events = "NotificareKit.NotificareEventsModuleImpl"
         case session = "NotificareKit.NotificareSessionModuleImpl"
+        case device = "NotificareKit.NotificareDeviceModuleImpl"
         case crashReporter = "NotificareKit.NotificareCrashReporterModuleImpl"
 
         // Peer modules

--- a/NotificareKit/Sources/Notificare+Augment.swift
+++ b/NotificareKit/Sources/Notificare+Augment.swift
@@ -19,6 +19,10 @@ internal extension Notificare {
         NotificareDeviceModuleImpl.instance
     }
 
+    func eventsImplementation() -> NotificareEventsModuleImpl {
+        NotificareEventsModuleImpl.instance
+    }
+
     func session() -> NotificareSessionModuleImpl {
         NotificareSessionModuleImpl.instance
     }

--- a/NotificareKit/Sources/NotificareEventsModule.swift
+++ b/NotificareKit/Sources/NotificareEventsModule.swift
@@ -34,11 +34,11 @@ public extension NotificareEventsModule {
 }
 
 public protocol NotificareInternalEventsModule {
-    func log(_ event: String, data: NotificareEventData?, for notification: String?, _ completion: @escaping NotificareCallback<Void>)
+    func log(_ event: String, data: NotificareEventData?, sessionId: String?, notificationId: String?, _ completion: @escaping NotificareCallback<Void>)
 }
 
 public extension NotificareInternalEventsModule {
-    func log(_ event: String, data: NotificareEventData? = nil, for notification: String? = nil, _ completion: @escaping NotificareCallback<Void>) {
-        log(event, data: data, for: notification, completion)
+    func log(_ event: String, data: NotificareEventData? = nil, sessionId: String? = nil, notificationId: String? = nil, _ completion: @escaping NotificareCallback<Void>) {
+        log(event, data: data, sessionId: sessionId, notificationId: notificationId, completion)
     }
 }

--- a/NotificareKit/Sources/NotificareEventsModule.swift
+++ b/NotificareKit/Sources/NotificareEventsModule.swift
@@ -5,31 +5,6 @@
 import Foundation
 
 public protocol NotificareEventsModule: AnyObject {
-    func logApplicationInstall(_ completion: @escaping NotificareCallback<Void>)
-
-    @available(iOS 13.0, *)
-    func logApplicationInstall() async throws
-
-    func logApplicationRegistration(_ completion: @escaping NotificareCallback<Void>)
-
-    @available(iOS 13.0, *)
-    func logApplicationRegistration() async throws
-
-    func logApplicationUpgrade(_ completion: @escaping NotificareCallback<Void>)
-
-    @available(iOS 13.0, *)
-    func logApplicationUpgrade() async throws
-
-    func logApplicationOpen(_ completion: @escaping NotificareCallback<Void>)
-
-    @available(iOS 13.0, *)
-    func logApplicationOpen() async throws
-
-    func logApplicationClose(sessionLength: Double, _ completion: @escaping NotificareCallback<Void>)
-
-    @available(iOS 13.0, *)
-    func logApplicationClose(sessionLength: Double) async throws
-
     // func logApplicationException(_ error: Error, _ completion: @escaping NotificareCallback<Void>)
 
     func logNotificationOpen(_ id: String, _ completion: @escaping NotificareCallback<Void>)

--- a/NotificarePushKit/Sources/NotificarePush+Events.swift
+++ b/NotificarePushKit/Sources/NotificarePush+Events.swift
@@ -8,16 +8,16 @@ import NotificareKit
 public extension NotificareEventsModule {
     func logNotificationReceived(_ id: String, _ completion: @escaping NotificareCallback<Void>) {
         let this = self as! NotificareInternalEventsModule
-        this.log("re.notifica.event.notification.Receive", data: nil, for: id, completion)
+        this.log("re.notifica.event.notification.Receive", notificationId: id, completion)
     }
 
     func logNotificationInfluenced(_ id: String, _ completion: @escaping NotificareCallback<Void>) {
         let this = self as! NotificareInternalEventsModule
-        this.log("re.notifica.event.notification.Influenced", data: nil, for: id, completion)
+        this.log("re.notifica.event.notification.Influenced", notificationId: id, completion)
     }
 
     func logPushRegistration(_ completion: @escaping NotificareCallback<Void>) {
         let this = self as! NotificareInternalEventsModule
-        this.log("re.notifica.event.push.Registration", data: nil, for: nil, completion)
+        this.log("re.notifica.event.push.Registration", notificationId: nil, completion)
     }
 }


### PR DESCRIPTION
The session should be started and logged during the launch flow.

The application close event should receive the session ID in the method parameters to prevent misuse of the current ID.

The session module should skip the unified configuration flow, and use a configuration provider to attach the lifecycle listeners.

The session should be stopped when Notificare is un-launched.