### PR TITLE
Prevent WebViews from being cleared too soon

### DIFF
--- a/NotificarePushUIKit/Sources/Notification Handlers/NotificareUrlViewController.swift
+++ b/NotificarePushUIKit/Sources/Notification Handlers/NotificareUrlViewController.swift
@@ -27,17 +27,13 @@ public class NotificareUrlViewController: NotificareBaseNotificationViewControll
         webView.addObserver(self, forKeyPath: NSStringFromSelector(#selector(getter: WKWebView.estimatedProgress)), options: .new, context: nil)
     }
 
-    override public func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        webView.removeObserver(self, forKeyPath: NSStringFromSelector(#selector(getter: WKWebView.estimatedProgress)))
 
         // NOTE: Loading a blank view to prevent the videos from continuing
         // playing after dismissing the view controller.
         webView.load(URLRequest(url: URL(string: "about:blank")!))
-    }
-
-    override public func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        webView.removeObserver(self, forKeyPath: NSStringFromSelector(#selector(getter: WKWebView.estimatedProgress)))
 
         DispatchQueue.main.async {
             Notificare.shared.pushUI().delegate?.notificare(Notificare.shared.pushUI(), didFinishPresentingNotification: self.notification)

--- a/NotificarePushUIKit/Sources/Notification Handlers/NotificareVideoViewController.swift
+++ b/NotificarePushUIKit/Sources/Notification Handlers/NotificareVideoViewController.swift
@@ -25,16 +25,12 @@ public class NotificareVideoViewController: NotificareBaseNotificationViewContro
         setupContent()
     }
 
-    override public func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
 
         // NOTE: Loading a blank view to prevent the videos from continuing
         // playing after dismissing the view controller.
         webView.load(URLRequest(url: URL(string: "about:blank")!))
-    }
-
-    override public func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
 
         DispatchQueue.main.async {
             Notificare.shared.pushUI().delegate?.notificare(Notificare.shared.pushUI(), didFinishPresentingNotification: self.notification)

--- a/NotificarePushUIKit/Sources/Notification Handlers/NotificareWebViewController.swift
+++ b/NotificarePushUIKit/Sources/Notification Handlers/NotificareWebViewController.swift
@@ -16,16 +16,12 @@ public class NotificareWebViewController: NotificareBaseNotificationViewControll
         setupContent()
     }
 
-    override public func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
 
         // NOTE: Loading a blank view to prevent the videos from continuing
         // playing after dismissing the view controller.
         webView.load(URLRequest(url: URL(string: "about:blank")!))
-    }
-
-    override public func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
 
         DispatchQueue.main.async {
             Notificare.shared.pushUI().delegate?.notificare(Notificare.shared.pushUI(), didFinishPresentingNotification: self.notification)


### PR DESCRIPTION
In earlier iOS versions, WebViews containing videos would keep playing sound after being dismissed. We should continue clearing the WebView's content but not before it actually disappears. 